### PR TITLE
Incorrect order of routing table entries

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -23,10 +23,10 @@ class CommunicationHandler(websocket.WebSocketHandler):
 app = web.Application([
         ('/', MainHandler),
         ('/ws', CommunicationHandler),
-        ('/(.*)', web.StaticFileHandler, dict(path='../client')),   # Not a good solution, should be changed in the future
         ('/js/(.*)', web.StaticFileHandler, dict(path='../client/js')),
         ('/css/(.*)', web.StaticFileHandler, dict(path='../client/css')),
-        ('/images/(.*)', web.StaticFileHandler, dict(path='../client/images'))
+        ('/images/(.*)', web.StaticFileHandler, dict(path='../client/images')),
+        ('/(.*)', web.StaticFileHandler, dict(path='../client'))   # Not a good solution, should be changed in the future
     ])
 
 


### PR DESCRIPTION
Due to http://tornadokevinlee.readthedocs.org/en/latest/guide/structure.html
"The routing table is a list of URLSpec objects (or tuples), each of which contains (at least) a regular expression and a handler class. Order matters; the first matching rule is used."
'/(.*)' pattern is used always when we refer to /css, /images and /js
